### PR TITLE
add proxy envirments detection strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "namecom_ddns"
 version = "0.6.1"
-authors = ["Zhang Maiyun <me@maiyun.me>", "dalance <dalance@gmail.com>"]
+authors = [
+    "Zhang Maiyun <me@maiyun.me>",
+    "dalance <dalance@gmail.com>",
+    "mingcheng <mingcheng@apache.org>",
+]
 edition = "2021"
 description = "Query IP addresses and update DNS records with Name.com API"
 readme = "README.md"
@@ -18,14 +22,24 @@ derive_deref = "1"
 futures = "0.3"
 libc = "0.2"
 log = "0.4"
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "socks"], default-features = false }
+reqwest = { version = "0.12", features = [
+    "json",
+    "rustls-tls",
+    "socks",
+], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 simplelog = "0.12"
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 thiserror = "2"
-tokio = { version = "^1, >=1.23.1", features = ["macros", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "^1, >=1.23.1", features = [
+    "macros",
+    "process",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 toml = "0.8"
 hickory-resolver = "0.24"
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -292,29 +292,31 @@ impl NameComDnsApi {
 
 #[tokio::test]
 async fn test_namecom_api_proxy_feature() {
-    env::set_var(ENV_NAMECOM_REQUEST_PROXY, "socks5://localhost:7890");
+    // start test if proxy is set
+    if env::var(ENV_NAMECOM_REQUEST_PROXY).is_ok() {
+        let api = NameComDnsApi::create("", "", "", 0).unwrap();
+        let result = api
+            .client
+            .get("https://httpbin.org/headers")
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
 
-    let api = NameComDnsApi::create("", "", "https://api.name.com", 0).unwrap();
-    let result = api
-        .client
-        .get("http://www.google.com/generate_204")
-        .timeout(Duration::from_secs(5))
-        .send()
-        .await
-        .unwrap();
-
-    assert!(result.status().is_success());
+        assert!(result.status().is_success());
+    }
 }
 
 #[tokio::test]
 #[should_panic]
 async fn test_namecom_api_proxy_feature_should_panic() {
+    // set a proxy that does not exist
     env::set_var(ENV_NAMECOM_REQUEST_PROXY, "http://localhost:80");
 
-    let api = NameComDnsApi::create("", "", "https://api.name.com", 0).unwrap();
+    let api = NameComDnsApi::create("", "", "", 0).unwrap();
     let result = api
         .client
-        .get("http://www.google.com/generate_204")
+        .get("https://httpbin.org/headers")
         .timeout(Duration::from_secs(2))
         .send()
         .await


### PR DESCRIPTION
In order to request the target's API, we may require a proxy server because name.com has IP whitelisting enabled by default. So I implemented a check: we connect via a particular proxy server if the matching environment variable is present.

However, we can connect by using environment variables like `http_proxy` or `all_proxy`. If the program in question is relying on static compilation (such as musl), this strategy will not work.